### PR TITLE
Correct the spelling of CocoaPods in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ A manager class for the new MultipeerConnectivity framework. Wraps up a bunch of
 
 <h2>Installation</h2>
 <hr>
-the prefered method is [Cocoapods](http://www.cocoapods.org), just put `pod 'TJLSessionManager', '1.0.2'` into your podfile. If you don't want to use cocoapods, just grab the files in the Source folder, drop them into your project and then `#import "TJLSessionManager.h"`. I am using the new Xcode modules, so you should not need to add any frameworks to your project.
+the prefered method is [CocoaPods](http://www.cocoapods.org), just put `pod 'TJLSessionManager', '1.0.2'` into your podfile. If you don't want to use cocoapods, just grab the files in the Source folder, drop them into your project and then `#import "TJLSessionManager.h"`. I am using the new Xcode modules, so you should not need to add any frameworks to your project.
 <h2>Usage</h2>
 <hr>
 There are several things that you need to do to connect two or more users with the Multipeer framework, and the basic steps of using TJLSessionManager are outlined below.<br>


### PR DESCRIPTION
This pull requests corrects the spelling of **CocoaPods** 🤓
https://github.com/CocoaPods/shared_resources/tree/master/media

<blockquote class="twitter-tweet" data-lang="en"><p lang="en" dir="ltr">One day I’ll make a bot that looks through the READMEs of all Pods, looks to see if it uses “Cocoapods” and PRs “CocoaPods” :D</p>&mdash; Ørta (@orta) <a href="https://twitter.com/orta/status/697374357975388160">February 10, 2016</a></blockquote>

<script async src="//platform.twitter.com/widgets.js" charset="utf-8"></script>


Created with [`cocoapods-readme`](https://github.com/dkhamsing/cocoapods-readme).  
